### PR TITLE
Update for renamed modules in Selenium2Library

### DIFF
--- a/src/ExtendedSelenium2Library/keywords/extendedelement.py
+++ b/src/ExtendedSelenium2Library/keywords/extendedelement.py
@@ -24,11 +24,11 @@ Extended Selenium2 Library - a web testing library with AngularJS support.
 from robot.api import logger
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.remote.webelement import WebElement
-from Selenium2Library.keywords import _ElementKeywords
+from Selenium2Library.keywords import ElementKeywords
 from ExtendedSelenium2Library.locators import ExtendedElementFinder
 
 
-class ExtendedElementKeywords(_ElementKeywords):
+class ExtendedElementKeywords(ElementKeywords):
     """ExtendedElementKeywords are web element execution in the requested browser."""
 
     def __init__(self):

--- a/src/ExtendedSelenium2Library/keywords/extendedformelement.py
+++ b/src/ExtendedSelenium2Library/keywords/extendedformelement.py
@@ -21,10 +21,10 @@
 Extended Selenium2 Library - a web testing library with AngularJS support.
 """
 
-from Selenium2Library.keywords import _FormElementKeywords
+from Selenium2Library.keywords import FormElementKeywords
 
 
-class ExtendedFormElementKeywords(_FormElementKeywords):
+class ExtendedFormElementKeywords(FormElementKeywords):
     """ExtendedFormElementKeywords are form element execution in the requested browser."""
 
     def __init__(self):

--- a/src/ExtendedSelenium2Library/keywords/extendedjavascript.py
+++ b/src/ExtendedSelenium2Library/keywords/extendedjavascript.py
@@ -22,10 +22,10 @@ Extended Selenium2 Library - a web testing library with AngularJS support.
 """
 
 from re import sub
-from Selenium2Library.keywords import _JavaScriptKeywords
+from Selenium2Library.keywords import JavaScriptKeywords
 
 
-class ExtendedJavascriptKeywords(_JavaScriptKeywords):
+class ExtendedJavascriptKeywords(JavaScriptKeywords):
     """ExtendedJavascriptKeywords are JavaScript related execution in the requested browser."""
     def __init__(self):
         super(ExtendedJavascriptKeywords, self).__init__()

--- a/src/ExtendedSelenium2Library/keywords/extendedselectelement.py
+++ b/src/ExtendedSelenium2Library/keywords/extendedselectelement.py
@@ -21,10 +21,10 @@
 Extended Selenium2 Library - a web testing library with AngularJS support.
 """
 
-from Selenium2Library.keywords import _SelectElementKeywords
+from Selenium2Library.keywords import SelectElementKeywords
 
 
-class ExtendedSelectElementKeywords(_SelectElementKeywords):
+class ExtendedSelectElementKeywords(SelectElementKeywords):
     """ExtendedSelectElementKeywords are select element execution in the requested browser."""
 
     def __init__(self):

--- a/src/ExtendedSelenium2Library/keywords/extendedwaiting.py
+++ b/src/ExtendedSelenium2Library/keywords/extendedwaiting.py
@@ -28,12 +28,12 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.expected_conditions import staleness_of, visibility_of
 from selenium.webdriver.support.ui import WebDriverWait
-from Selenium2Library.keywords import _WaitingKeywords
+from Selenium2Library.keywords import WaitingKeywords
 from ExtendedSelenium2Library.decorators import inherit_docs
 
 
 @inherit_docs
-class ExtendedWaitingKeywords(_WaitingKeywords):
+class ExtendedWaitingKeywords(WaitingKeywords):
     """ExtendedWaitingKeywords are waiting related execution towards the requested browser."""
     def __init__(self):
         super(ExtendedWaitingKeywords, self).__init__()

--- a/test/utest/test_extendedelement.py
+++ b/test/utest/test_extendedelement.py
@@ -27,7 +27,7 @@ import unittest
 import mock
 from ExtendedSelenium2Library.keywords import ExtendedElementKeywords
 from selenium.webdriver.remote.webelement import WebElement
-from Selenium2Library.keywords import _ElementKeywords
+from Selenium2Library.keywords import ElementKeywords
 
 
 class ExtendedElementTests(unittest.TestCase):
@@ -50,7 +50,7 @@ class ExtendedElementTests(unittest.TestCase):
 
     def test_should_inherit_keywords(self):
         """Extended element instance should inherit Selenium2 element instances."""
-        self.assertIsInstance(self.element, _ElementKeywords)
+        self.assertIsInstance(self.element, ElementKeywords)
 
     def test_should_click_element(self):
         """Should click an element."""

--- a/test/utest/test_extendedformelement.py
+++ b/test/utest/test_extendedformelement.py
@@ -27,7 +27,7 @@ import unittest
 import mock
 from ExtendedSelenium2Library.keywords import ExtendedFormElementKeywords
 from selenium.webdriver.remote.webelement import WebElement
-from Selenium2Library.keywords import _FormElementKeywords
+from Selenium2Library.keywords import FormElementKeywords
 
 
 class ExtendedFormElementTests(unittest.TestCase):
@@ -49,7 +49,7 @@ class ExtendedFormElementTests(unittest.TestCase):
 
     def test_should_inherit_keywords(self):
         """Extended form element instance should inherit Selenium2 form element instances."""
-        self.assertIsInstance(self.element, _FormElementKeywords)
+        self.assertIsInstance(self.element, FormElementKeywords)
 
     def test_should_click_input_button(self):
         """Should click an input button."""

--- a/test/utest/test_extendedjavascript.py
+++ b/test/utest/test_extendedjavascript.py
@@ -26,7 +26,7 @@ path.append('src')
 import unittest
 import mock
 from ExtendedSelenium2Library.keywords import ExtendedJavascriptKeywords
-from Selenium2Library.keywords import _JavaScriptKeywords
+from Selenium2Library.keywords import JavaScriptKeywords
 
 
 class ExtendedJavascriptTests(unittest.TestCase):
@@ -45,7 +45,7 @@ class ExtendedJavascriptTests(unittest.TestCase):
 
     def test_should_inherit_keywords(self):
         """Extended Javascript instance should inherit Selenium2 Javascript instances."""
-        self.assertIsInstance(self.script, _JavaScriptKeywords)
+        self.assertIsInstance(self.script, JavaScriptKeywords)
 
     def test_execute_async_js_with_replaced_vars(self):
         """Should execute async js with replaced vars."""

--- a/test/utest/test_extendedselectelement.py
+++ b/test/utest/test_extendedselectelement.py
@@ -26,7 +26,7 @@ path.append('src')
 import unittest
 import mock
 from ExtendedSelenium2Library.keywords import ExtendedSelectElementKeywords
-from Selenium2Library.keywords import _SelectElementKeywords
+from Selenium2Library.keywords import SelectElementKeywords
 
 
 class ExtendedSelectElementTests(unittest.TestCase):
@@ -43,10 +43,10 @@ class ExtendedSelectElementTests(unittest.TestCase):
 
     def test_should_inherit_keywords(self):
         """Extended select element instance should inherit Selenium2 select element instances."""
-        self.assertIsInstance(self.element, _SelectElementKeywords)
+        self.assertIsInstance(self.element, SelectElementKeywords)
 
     @mock.patch("ExtendedSelenium2Library.keywords.extendedselectelement."
-                "_SelectElementKeywords.select_all_from_list")
+                "SelectElementKeywords.select_all_from_list")
     def test_should_select_all_from_list(self, mock_select_all_from_list):
         """Should select all option items from list."""
         # pylint: disable=protected-access
@@ -56,7 +56,7 @@ class ExtendedSelectElementTests(unittest.TestCase):
         self.element._element_trigger_change.assert_called_with(self.locator)
 
     @mock.patch("ExtendedSelenium2Library.keywords.extendedselectelement."
-                "_SelectElementKeywords.select_from_list")
+                "SelectElementKeywords.select_from_list")
     def test_should_select_from_list(self, mock_select_from_list):
         """Should select option items from list by item."""
         # pylint: disable=protected-access
@@ -66,7 +66,7 @@ class ExtendedSelectElementTests(unittest.TestCase):
         self.element._element_trigger_change.assert_called_with(self.locator)
 
     @mock.patch("ExtendedSelenium2Library.keywords.extendedselectelement."
-                "_SelectElementKeywords.select_from_list_by_index")
+                "SelectElementKeywords.select_from_list_by_index")
     def test_should_select_from_list_by_index(self, mock_select_from_list_by_index):
         """Should select option items from list by index."""
         # pylint: disable=protected-access
@@ -76,7 +76,7 @@ class ExtendedSelectElementTests(unittest.TestCase):
         self.element._element_trigger_change.assert_called_with(self.locator)
 
     @mock.patch("ExtendedSelenium2Library.keywords.extendedselectelement."
-                "_SelectElementKeywords.select_from_list_by_label")
+                "SelectElementKeywords.select_from_list_by_label")
     def test_should_select_from_list_by_label(self, mock_select_from_list_by_label):
         """Should select option items from list by label."""
         # pylint: disable=protected-access
@@ -86,7 +86,7 @@ class ExtendedSelectElementTests(unittest.TestCase):
         self.element._element_trigger_change.assert_called_with(self.locator)
 
     @mock.patch("ExtendedSelenium2Library.keywords.extendedselectelement."
-                "_SelectElementKeywords.select_from_list_by_value")
+                "SelectElementKeywords.select_from_list_by_value")
     def test_should_select_from_list_by_value(self, mock_select_from_list_by_value):
         """Should select option items from list by value."""
         # pylint: disable=protected-access


### PR DESCRIPTION
In the (unreleased) tip version of Selenium2Library some modules have been renamed to remove the leading underscore. I needed to use the tip version so I made the changes, and I figured you'll need to update at some point so I may as well pull request them for when you do.

Hope it saves you a bit of time :+1: 